### PR TITLE
Fix missing YouTube API key crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,8 @@ streamlit-authenticator==0.4.2
 streamlit-option-menu==0.4.0
 pandas
 requests
+```
+
+### Configuration de la clé API YouTube
+
+Pour que la recherche de vidéos fonctionne, renseignez votre clé API dans un fichier `secrets.toml` ou via la variable d'environnement `YOUTUBE_API_KEY`.

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import os
 import streamlit as st
 import pandas as pd
 import requests
@@ -6,7 +7,11 @@ from streamlit_folium import st_folium
 from streamlit_option_menu import option_menu
 from streamlit_authenticator import Authenticate
 
-API_KEY = st.secrets["api"]["youtube_key"]
+# Récupération de la clé API YouTube depuis les secrets ou les variables
+# d'environnement pour éviter une erreur si le fichier secrets.toml est absent
+API_KEY = st.secrets.get("api", {}).get("youtube_key")
+if not API_KEY:
+    API_KEY = os.getenv("YOUTUBE_API_KEY", "")
 st.title("Bienvenue sur l'application des parcs et jardins de Bruxelles 🌳")
 
 # Authentification
@@ -108,6 +113,8 @@ elif selection == "Parcs et jardins de Bruxelles":
             return None, None
 
         def chercher_video_youtube(lieu, api_key):
+            if not api_key:
+                return None
             lat, lon = API_address(lieu)
             params = {
                 "part": "snippet",
@@ -130,6 +137,8 @@ elif selection == "Parcs et jardins de Bruxelles":
             video_url = chercher_video_youtube(lieu_select, API_KEY)
             if video_url:
                 st.video(video_url)
+            elif not API_KEY:
+                st.error("Clé API YouTube manquante.")
             else:
                 st.warning("Aucune vidéo trouvée pour ce lieu.")
     


### PR DESCRIPTION
## Summary
- avoid crash if `secrets.toml` is absent by reading `YOUTUBE_API_KEY` env var
- warn the user when no API key is configured
- document the API key configuration

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6844a1e9aaa08329ac74fead7d4bd2d4